### PR TITLE
Add Pomelo 6.2 package

### DIFF
--- a/LibraryBackend/LibraryBackend.csproj
+++ b/LibraryBackend/LibraryBackend.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/LibraryBackend/Startup.cs
+++ b/LibraryBackend/Startup.cs
@@ -28,6 +28,9 @@ namespace LibraryBackend
 
         public void ConfigureServices(IServiceCollection services)
         {
+            var jwtKey = Environment.GetEnvironmentVariable("JWT_KEY");
+            var connectionString = Environment.GetEnvironmentVariable("JAWSDB_URL");
+
             services
             .AddControllers(options => options.Filters.Add(typeof(FilterExceptions)))
             .AddJsonOptions(options =>
@@ -40,7 +43,7 @@ namespace LibraryBackend
 
             services.AddDbContext<ApplicationDBContext>(options =>
             {
-                options.UseSqlServer(Configuration.GetConnectionString("SQL_CONNECTIONSTRING")!);
+                options.UseMySql(connectionString, new MySqlServerVersion(new Version(8, 0)));
             });
 
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -50,7 +53,7 @@ namespace LibraryBackend
                     ValidateAudience = false,
                     ValidateLifetime = true,
                     ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration["JWT_KEY"]!)),
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey!)),
                     ClockSkew = TimeSpan.Zero
                 });
 

--- a/LibraryBackend/appsettings.json
+++ b/LibraryBackend/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "SQL_CONNECTIONSTRING": "Server=sqlserver;Database=LibraryBackend;User Id=sa;Password=Kalif@890;"
+    "SQL_CONNECTIONSTRING": ""
   },
-  "JWT_KEY": "ASPRGERHDNFHRTUFDDIURUJDWYOMBYONGLEIRJDFNSJHRHDFNWOFHFNFJHSHGFRUALLDOREKZDPIEYURND"
+  "JWT_KEY": ""
 }

--- a/heroku.yaml
+++ b/heroku.yaml
@@ -1,3 +1,0 @@
-build:
-  docker:
-    web: LibraryBackend/Dockerfile


### PR DESCRIPTION
## Background
Due to Heroku accepting a MySql Database, and LIbraryBackend project being configured to work with an MSSQL engine, we need to create a new configuration that can integrate with Heroku. Hence, we added new methods that can be able to handle this purpose. 

## Changes done
Were added new methods to `Startup.cs` file that can handle a new MySQL connection through Heroku. Besides, it was added a new Nuget package: `Pomelo.EntityFramework 6.2` allows integration of this kind of connection. 

## Pending to be done
The `Heroku.yml` file was removed from the root repository. It will be necessary to test this change because unexpected behavior might be detected during build and deployment.